### PR TITLE
Run prettier on TS schema as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run validate:schema
+      - name: Check TypeScript definitions
+        run: npm run check:schema:ts
 
-      - run: npm run generate:json
       - name: Verify that `npm run generate:json` did not change outputs (if it did, please re-run it and re-commit!)
-        run: git diff --exit-code
+        run: npm run check:schema:json

--- a/.github/workflows/markdown-format.yml
+++ b/.github/workflows/markdown-format.yml
@@ -13,14 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Check markdown formatting
-        run: npm run format:check
+        run: npm run check:docs:format
+
+      - name: Check markdown links
+        run: npm run check:docs:links

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "scripts": {
     "check": "npm run check:schema && npm run check:docs",
     "check:schema": "npm run check:schema:ts && npm run check:schema:json",
-    "check:schema:ts": "tsc",
+    "check:schema:ts": "tsc && prettier --check \"schema/**/*.ts\"",
     "check:schema:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" | cat | cmp \"${f%ts}json\" - || exit 1; done",
     "check:docs": "npm run check:docs:format && npm run check:docs:links",
     "check:docs:format": "prettier --check \"**/*.md\"",
     "check:docs:links": "cd docs && mintlify broken-links",
     "generate:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" -o \"${f%ts}json\"; done",
-    "format": "prettier --write \"**/*.md\"",
+    "format": "prettier --write \"**/*.md\" \"schema/**/schema.ts\"",
     "serve:docs": "cd docs && mintlify dev"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,16 @@
     ]
   },
   "scripts": {
-    "validate:schema": "tsc",
+    "check": "npm run check:schema && npm run check:docs",
+    "check:schema": "npm run check:schema:ts && npm run check:schema:json",
+    "check:schema:ts": "tsc",
+    "check:schema:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" | cat | cmp \"${f%ts}json\" - || exit 1; done",
+    "check:docs": "npm run check:docs:format && npm run check:docs:links",
+    "check:docs:format": "prettier --check \"**/*.md\"",
+    "check:docs:links": "cd docs && mintlify broken-links",
     "generate:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" -o \"${f%ts}json\"; done",
-    "serve:docs": "cd docs && mintlify dev",
     "format": "prettier --write \"**/*.md\"",
-    "format:check": "prettier --check \"**/*.md\""
+    "serve:docs": "cd docs && mintlify dev"
   },
   "devDependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
I don't see anywhere that applies/checks for formatting of the `schema.ts`, which should also be normalized, and TS is supported by prettier.

Also, selfish motive to be included as co-author due to the usage of `mintlify broken-links` and because of unemployed. 🎉 